### PR TITLE
ci: publish helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,3 +20,5 @@ jobs:
     needs: [docker]
     with:
       CHART_LOCATION: helm
+      PUSH_TO_GITHUB: true
+      UPDATE_BRANCH: main


### PR DESCRIPTION
Needs #7 and https://github.com/naviteq/helm-charts/pull/2 merged first